### PR TITLE
fix(deps): pin golang.org/x/text to v0.41.0 (CVE-2026-56852)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,11 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+// CVE-2026-56852 / GO-2026-5970: infinite loop in golang.org/x/text/unicode/norm
+// on invalid UTF-8 input. x/text is pulled in transitively via
+// prometheus/client_golang and prometheus/common and is not reachable from this
+// module's packages, so `go get` + `go mod tidy` cannot raise it -- module-graph
+// pruning drops the unused require and the selected version falls back. nancy
+// audits the whole module graph and gates go-build, so pin it here.
+replace golang.org/x/text => golang.org/x/text v0.41.0


### PR DESCRIPTION
Pins `golang.org/x/text` v0.40.0 -> v0.41.0 to patch CVE-2026-56852 / GO-2026-5970 (infinite loop in `unicode/norm` on invalid UTF-8).

`nancy` audits the full module graph and gates the shared `go-build` job, so this CVE was failing CI on **every** open PR in this repo, including the Align files PR #125.

### Why a `replace` and not `go get`

`x/text` is transitive-only here (via `prometheus/client_golang v1.24.1` and `prometheus/common v0.70.1`) and is not reachable from this module's packages. `go get golang.org/x/text@v0.41.0` followed by `go mod tidy` silently reverts to v0.40.0 — module-graph pruning drops the unused explicit require, so the selected version falls back to what the prometheus modules ask for. A `replace` survives `tidy`.

The alternative would be bumping `prometheus/client_golang`/`common` until they carry a patched x/text; the `replace` is the smaller, immediately-available change and can be dropped once those bumps land.

### Verification

- `go list -m golang.org/x/text` → `v0.40.0 => v0.41.0`
- `go mod tidy -diff` → clean
- `go build ./...` → OK
- `go test ./...` → pass (no test files in this module)

Fleet-wide tracking: giantswarm/github#5786